### PR TITLE
Update runtime to 21.08

### DIFF
--- a/org.zaproxy.ZAP.json
+++ b/org.zaproxy.ZAP.json
@@ -1,7 +1,7 @@
 {
     "id": "org.zaproxy.ZAP",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "zap",
     "separate-locales": false,


### PR DESCRIPTION
The version in use, 19.08, is no longer supported.

Fix #5.