### PR TITLE
Update ZAP to 2.11.1

### DIFF
--- a/org.zaproxy.ZAP.appdata.xml
+++ b/org.zaproxy.ZAP.appdata.xml
@@ -35,7 +35,7 @@
   <developer_name>The ZAP Development Team</developer_name>
   <url type="homepage">https://www.zaproxy.org</url>
   <releases>
-    <release version="2.11.0" date="2021-10-07" />
+    <release version="2.11.1" date="2021-12-10" />
   </releases>
   <content_rating type="oars-1.1" />
 </component>

--- a/org.zaproxy.ZAP.json
+++ b/org.zaproxy.ZAP.json
@@ -42,8 +42,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/zaproxy/zaproxy/releases/download/v2.11.0/ZAP_2.11.0_Linux.tar.gz",
-                    "sha256": "c2beb84f7fa9b39af657bdb3e0d0dba96425257ea48e0e8b22eeeccd8d55681e"
+                    "url": "https://github.com/zaproxy/zaproxy/releases/download/v2.11.1/ZAP_2.11.1_Linux.tar.gz",
+                    "sha256": "5f83666e5863f4f94eac583942f1c4e15f9cc7b7307d05bc6ce6545265c6382c"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Update download link and hash.
Update release date.