### PR TITLE
Update ZAP to 2.12.0

### DIFF
--- a/org.zaproxy.ZAP.appdata.xml
+++ b/org.zaproxy.ZAP.appdata.xml
@@ -35,7 +35,7 @@
   <developer_name>The ZAP Development Team</developer_name>
   <url type="homepage">https://www.zaproxy.org</url>
   <releases>
-    <release version="2.11.1" date="2021-12-10" />
+    <release version="2.12.0" date="2022-10-27" />
   </releases>
   <content_rating type="oars-1.1" />
 </component>

--- a/org.zaproxy.ZAP.json
+++ b/org.zaproxy.ZAP.json
@@ -42,8 +42,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/zaproxy/zaproxy/releases/download/v2.11.1/ZAP_2.11.1_Linux.tar.gz",
-                    "sha256": "5f83666e5863f4f94eac583942f1c4e15f9cc7b7307d05bc6ce6545265c6382c"
+                    "url": "https://github.com/zaproxy/zaproxy/releases/download/v2.12.0/ZAP_2.12.0_Linux.tar.gz",
+                    "sha256": "9c4493c991cb9347063864d2436a3795cf3b69760625e7b3db401cd342d3fc55"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Update download link and hash.
Update release date.