### PR TITLE
Update runtime to FreeDesktop 23.08

### DIFF
--- a/org.zaproxy.ZAP.json
+++ b/org.zaproxy.ZAP.json
@@ -1,7 +1,7 @@
 {
     "id": "org.zaproxy.ZAP",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "zap",
     "separate-locales": false,


### PR DESCRIPTION
I created this PR to make this changes:

- Update freedesktop runtime to 23.08
- ~Update to OpenJDK 17 (since version 11 EOL at the end of this month)~
- ~Add automatic PR creations by using [flathub external checker](https://docs.flathub.org/docs/for-app-authors/external-data-checker/).~
- ~Run flathub external checker to validate the configuration and commit the changes it made.~

Please let me know if you prefer separated PR, or to add or remove any of the changes for this PR.

Regarding the flathub external checker configuration, the flathub bot will create PR on each new zaproxy release, an option can be configured to automatically merge those PR by changing the file `flathub.json` by something like this:

```json
{
  "only-arches": ["x86_64"],
  "automerge-flathubbot-prs": true
}
```

Let me know also if you want me to add this change in this PR.